### PR TITLE
ITR-0001, ITR-0002: Add static mappings for continents and subregions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "yaovicoder/intl-region",
+    "description": "A PHP package for UN M49 region-based country filtering with Symfony integration",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Yaovi Ametepe",
+            "email": "yaovicoder@gmail.com"
+        }
+    ],
+    "require": {
+        "php": ">=8.1",
+        "symfony/intl": "^6.0|^7.0",
+        "symfony/console": "^6.0|^7.0",
+        "symfony/dependency-injection": "^6.0|^7.0",
+        "symfony/config": "^6.0|^7.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0",
+        "symfony/phpunit-bridge": "^6.0|^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ydee\\IntlRegion\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ydee\\IntlRegion\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true,
+        "optimize-autoloader": true
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true,
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "1.0-dev"
+        }
+    }
+} 

--- a/src/Mapping/ContinentMapping.php
+++ b/src/Mapping/ContinentMapping.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ydee\IntlRegion\Mapping;
+
+/**
+ * Static mapping of ISO 3166-1 country codes to UN M49 continent codes.
+ * 
+ * This mapping follows the UN M49 standard for geographic regions.
+ * Continent codes:
+ * - 002: Africa
+ * - 019: Americas
+ * - 142: Asia
+ * - 150: Europe
+ * - 009: Oceania
+ */
+final class ContinentMapping
+{
+    /**
+     * Mapping of country codes to continent codes.
+     * 
+     * @var array<string, string>
+     */
+    private static array $mapping = [
+        // Africa (002)
+        'DZ' => '002', // Algeria
+        'AO' => '002', // Angola
+        'BJ' => '002', // Benin
+        'BW' => '002', // Botswana
+        'BF' => '002', // Burkina Faso
+        'BI' => '002', // Burundi
+        'CM' => '002', // Cameroon
+        'CV' => '002', // Cape Verde
+        'CF' => '002', // Central African Republic
+        'TD' => '002', // Chad
+        'KM' => '002', // Comoros
+        'CG' => '002', // Congo
+        'CD' => '002', // Congo, Democratic Republic of the
+        'CI' => '002', // Côte d'Ivoire
+        'DJ' => '002', // Djibouti
+        'EG' => '002', // Egypt
+        'GQ' => '002', // Equatorial Guinea
+        'ER' => '002', // Eritrea
+        'ET' => '002', // Ethiopia
+        'GA' => '002', // Gabon
+        'GM' => '002', // Gambia
+        'GH' => '002', // Ghana
+        'GN' => '002', // Guinea
+        'GW' => '002', // Guinea-Bissau
+        'KE' => '002', // Kenya
+        'LS' => '002', // Lesotho
+        'LR' => '002', // Liberia
+        'LY' => '002', // Libya
+        'MG' => '002', // Madagascar
+        'MW' => '002', // Malawi
+        'ML' => '002', // Mali
+        'MR' => '002', // Mauritania
+        'MU' => '002', // Mauritius
+        'MA' => '002', // Morocco
+        'MZ' => '002', // Mozambique
+        'NA' => '002', // Namibia
+        'NE' => '002', // Niger
+        'NG' => '002', // Nigeria
+        'RW' => '002', // Rwanda
+        'ST' => '002', // Sao Tome and Principe
+        'SN' => '002', // Senegal
+        'SC' => '002', // Seychelles
+        'SL' => '002', // Sierra Leone
+        'SO' => '002', // Somalia
+        'ZA' => '002', // South Africa
+        'SS' => '002', // South Sudan
+        'SD' => '002', // Sudan
+        'SZ' => '002', // Eswatini
+        'TZ' => '002', // Tanzania
+        'TG' => '002', // Togo
+        'TN' => '002', // Tunisia
+        'UG' => '002', // Uganda
+        'ZM' => '002', // Zambia
+        'ZW' => '002', // Zimbabwe
+
+        // Americas (019)
+        'AR' => '019', // Argentina
+        'BO' => '019', // Bolivia
+        'BR' => '019', // Brazil
+        'CL' => '019', // Chile
+        'CO' => '019', // Colombia
+        'EC' => '019', // Ecuador
+        'GY' => '019', // Guyana
+        'PY' => '019', // Paraguay
+        'PE' => '019', // Peru
+        'SR' => '019', // Suriname
+        'UY' => '019', // Uruguay
+        'VE' => '019', // Venezuela
+        'BZ' => '019', // Belize
+        'CR' => '019', // Costa Rica
+        'SV' => '019', // El Salvador
+        'GT' => '019', // Guatemala
+        'HN' => '019', // Honduras
+        'MX' => '019', // Mexico
+        'NI' => '019', // Nicaragua
+        'PA' => '019', // Panama
+        'CA' => '019', // Canada
+        'US' => '019', // United States
+        'AG' => '019', // Antigua and Barbuda
+        'BS' => '019', // Bahamas
+        'BB' => '019', // Barbados
+        'CU' => '019', // Cuba
+        'DM' => '019', // Dominica
+        'DO' => '019', // Dominican Republic
+        'GD' => '019', // Grenada
+        'HT' => '019', // Haiti
+        'JM' => '019', // Jamaica
+        'KN' => '019', // Saint Kitts and Nevis
+        'LC' => '019', // Saint Lucia
+        'VC' => '019', // Saint Vincent and the Grenadines
+        'TT' => '019', // Trinidad and Tobago
+
+        // Asia (142)
+        'AF' => '142', // Afghanistan
+        'BH' => '142', // Bahrain
+        'BD' => '142', // Bangladesh
+        'BT' => '142', // Bhutan
+        'IO' => '142', // British Indian Ocean Territory
+        'BN' => '142', // Brunei Darussalam
+        'KH' => '142', // Cambodia
+        'CN' => '142', // China
+        'HK' => '142', // Hong Kong
+        'IN' => '142', // India
+        'ID' => '142', // Indonesia
+        'IR' => '142', // Iran
+        'IQ' => '142', // Iraq
+        'IL' => '142', // Israel
+        'JP' => '142', // Japan
+        'JO' => '142', // Jordan
+        'KZ' => '142', // Kazakhstan
+        'KP' => '142', // North Korea
+        'KR' => '142', // South Korea
+        'KW' => '142', // Kuwait
+        'KG' => '142', // Kyrgyzstan
+        'LA' => '142', // Laos
+        'LB' => '142', // Lebanon
+        'MO' => '142', // Macao
+        'MY' => '142', // Malaysia
+        'MV' => '142', // Maldives
+        'MN' => '142', // Mongolia
+        'MM' => '142', // Myanmar
+        'NP' => '142', // Nepal
+        'OM' => '142', // Oman
+        'PK' => '142', // Pakistan
+        'PH' => '142', // Philippines
+        'QA' => '142', // Qatar
+        'SA' => '142', // Saudi Arabia
+        'SG' => '142', // Singapore
+        'LK' => '142', // Sri Lanka
+        'SY' => '142', // Syria
+        'TW' => '142', // Taiwan
+        'TJ' => '142', // Tajikistan
+        'TH' => '142', // Thailand
+        'TL' => '142', // Timor-Leste
+        'AE' => '142', // United Arab Emirates
+        'UZ' => '142', // Uzbekistan
+        'VN' => '142', // Vietnam
+        'YE' => '142', // Yemen
+
+        // Europe (150)
+        'AL' => '150', // Albania
+        'AD' => '150', // Andorra
+        'AM' => '150', // Armenia
+        'AT' => '150', // Austria
+        'AZ' => '150', // Azerbaijan
+        'BY' => '150', // Belarus
+        'BE' => '150', // Belgium
+        'BA' => '150', // Bosnia and Herzegovina
+        'BG' => '150', // Bulgaria
+        'HR' => '150', // Croatia
+        'CY' => '150', // Cyprus
+        'CZ' => '150', // Czech Republic
+        'DK' => '150', // Denmark
+        'EE' => '150', // Estonia
+        'FI' => '150', // Finland
+        'FR' => '150', // France
+        'GE' => '150', // Georgia
+        'DE' => '150', // Germany
+        'GR' => '150', // Greece
+        'HU' => '150', // Hungary
+        'IS' => '150', // Iceland
+        'IE' => '150', // Ireland
+        'IT' => '150', // Italy
+        'LV' => '150', // Latvia
+        'LI' => '150', // Liechtenstein
+        'LT' => '150', // Lithuania
+        'LU' => '150', // Luxembourg
+        'MT' => '150', // Malta
+        'MD' => '150', // Moldova
+        'MC' => '150', // Monaco
+        'ME' => '150', // Montenegro
+        'NL' => '150', // Netherlands
+        'MK' => '150', // North Macedonia
+        'NO' => '150', // Norway
+        'PL' => '150', // Poland
+        'PT' => '150', // Portugal
+        'RO' => '150', // Romania
+        'RU' => '150', // Russia
+        'SM' => '150', // San Marino
+        'RS' => '150', // Serbia
+        'SK' => '150', // Slovakia
+        'SI' => '150', // Slovenia
+        'ES' => '150', // Spain
+        'SE' => '150', // Sweden
+        'CH' => '150', // Switzerland
+        'TR' => '150', // Turkey
+        'UA' => '150', // Ukraine
+        'GB' => '150', // United Kingdom
+        'VA' => '150', // Vatican City
+
+        // Oceania (009)
+        'AU' => '009', // Australia
+        'FJ' => '009', // Fiji
+        'KI' => '009', // Kiribati
+        'MH' => '009', // Marshall Islands
+        'FM' => '009', // Micronesia
+        'NR' => '009', // Nauru
+        'NZ' => '009', // New Zealand
+        'PW' => '009', // Palau
+        'PG' => '009', // Papua New Guinea
+        'WS' => '009', // Samoa
+        'SB' => '009', // Solomon Islands
+        'TO' => '009', // Tonga
+        'TV' => '009', // Tuvalu
+        'VU' => '009', // Vanuatu
+    ];
+
+    /**
+     * Get the continent code for a given country code.
+     * 
+     * @param string $countryCode ISO 3166-1 alpha-2 country code
+     * @return string|null UN M49 continent code or null if not found
+     */
+    public static function getContinentCode(string $countryCode): ?string
+    {
+        return self::$mapping[strtoupper($countryCode)] ?? null;
+    }
+
+    /**
+     * Get all country codes for a given continent.
+     * 
+     * @param string $continentCode UN M49 continent code
+     * @return array<string> Array of country codes
+     */
+    public static function getCountriesByContinent(string $continentCode): array
+    {
+        return array_keys(array_filter(self::$mapping, fn($code) => $code === $continentCode));
+    }
+
+    /**
+     * Get all available continent codes.
+     * 
+     * @return array<string> Array of continent codes
+     */
+    public static function getAvailableContinentCodes(): array
+    {
+        return array_unique(array_values(self::$mapping));
+    }
+
+    /**
+     * Get all available country codes.
+     * 
+     * @return array<string> Array of country codes
+     */
+    public static function getAvailableCountryCodes(): array
+    {
+        return array_keys(self::$mapping);
+    }
+
+    /**
+     * Check if a country code exists in the mapping.
+     * 
+     * @param string $countryCode ISO 3166-1 alpha-2 country code
+     * @return bool True if the country code exists
+     */
+    public static function hasCountryCode(string $countryCode): bool
+    {
+        return isset(self::$mapping[strtoupper($countryCode)]);
+    }
+
+    /**
+     * Check if a continent code exists in the mapping.
+     * 
+     * @param string $continentCode UN M49 continent code
+     * @return bool True if the continent code exists
+     */
+    public static function hasContinentCode(string $continentCode): bool
+    {
+        return in_array($continentCode, self::getAvailableContinentCodes(), true);
+    }
+} 

--- a/src/Mapping/SubregionMapping.php
+++ b/src/Mapping/SubregionMapping.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ydee\IntlRegion\Mapping;
+
+/**
+ * Static mapping of ISO 3166-1 country codes to UN M49 subregion codes.
+ * 
+ * This mapping follows the UN M49 standard for geographic subregions.
+ * Subregion codes include:
+ * - 014: Eastern Africa
+ * - 017: Middle Africa
+ * - 015: Northern Africa
+ * - 018: Southern Africa
+ * - 011: Western Africa
+ * - 005: South America
+ * - 013: Central America
+ * - 021: Northern America
+ * - 029: Caribbean
+ * - 030: Eastern Asia
+ * - 034: Southern Asia
+ * - 035: South-Eastern Asia
+ * - 143: Central Asia
+ * - 145: Western Asia
+ * - 151: Eastern Europe
+ * - 154: Northern Europe
+ * - 039: Southern Europe
+ * - 155: Western Europe
+ * - 053: Australia and New Zealand
+ * - 054: Melanesia
+ * - 057: Micronesia
+ * - 061: Polynesia
+ */
+final class SubregionMapping
+{
+    /**
+     * Mapping of country codes to subregion codes.
+     * 
+     * @var array<string, string>
+     */
+    private static array $mapping = [
+        // Eastern Africa (014)
+        'BI' => '014', // Burundi
+        'KM' => '014', // Comoros
+        'DJ' => '014', // Djibouti
+        'ER' => '014', // Eritrea
+        'ET' => '014', // Ethiopia
+        'KE' => '014', // Kenya
+        'MG' => '014', // Madagascar
+        'MW' => '014', // Malawi
+        'MU' => '014', // Mauritius
+        'MZ' => '014', // Mozambique
+        'RW' => '014', // Rwanda
+        'SC' => '014', // Seychelles
+        'SO' => '014', // Somalia
+        'SS' => '014', // South Sudan
+        'TZ' => '014', // Tanzania
+        'UG' => '014', // Uganda
+        'ZM' => '014', // Zambia
+        'ZW' => '014', // Zimbabwe
+
+        // Middle Africa (017)
+        'AO' => '017', // Angola
+        'CM' => '017', // Cameroon
+        'CF' => '017', // Central African Republic
+        'TD' => '017', // Chad
+        'CG' => '017', // Congo
+        'CD' => '017', // Congo, Democratic Republic of the
+        'GQ' => '017', // Equatorial Guinea
+        'GA' => '017', // Gabon
+        'ST' => '017', // Sao Tome and Principe
+
+        // Northern Africa (015)
+        'DZ' => '015', // Algeria
+        'EG' => '015', // Egypt
+        'LY' => '015', // Libya
+        'MA' => '015', // Morocco
+        'SD' => '015', // Sudan
+        'TN' => '015', // Tunisia
+
+        // Southern Africa (018)
+        'BW' => '018', // Botswana
+        'LS' => '018', // Lesotho
+        'NA' => '018', // Namibia
+        'ZA' => '018', // South Africa
+        'SZ' => '018', // Eswatini
+
+        // Western Africa (011)
+        'BJ' => '011', // Benin
+        'BF' => '011', // Burkina Faso
+        'CV' => '011', // Cape Verde
+        'CI' => '011', // Côte d'Ivoire
+        'GM' => '011', // Gambia
+        'GH' => '011', // Ghana
+        'GN' => '011', // Guinea
+        'GW' => '011', // Guinea-Bissau
+        'LR' => '011', // Liberia
+        'ML' => '011', // Mali
+        'MR' => '011', // Mauritania
+        'NE' => '011', // Niger
+        'NG' => '011', // Nigeria
+        'SN' => '011', // Senegal
+        'SL' => '011', // Sierra Leone
+        'TG' => '011', // Togo
+
+        // South America (005)
+        'AR' => '005', // Argentina
+        'BO' => '005', // Bolivia
+        'BR' => '005', // Brazil
+        'CL' => '005', // Chile
+        'CO' => '005', // Colombia
+        'EC' => '005', // Ecuador
+        'GY' => '005', // Guyana
+        'PY' => '005', // Paraguay
+        'PE' => '005', // Peru
+        'SR' => '005', // Suriname
+        'UY' => '005', // Uruguay
+        'VE' => '005', // Venezuela
+
+        // Central America (013)
+        'BZ' => '013', // Belize
+        'CR' => '013', // Costa Rica
+        'SV' => '013', // El Salvador
+        'GT' => '013', // Guatemala
+        'HN' => '013', // Honduras
+        'MX' => '013', // Mexico
+        'NI' => '013', // Nicaragua
+        'PA' => '013', // Panama
+
+        // Northern America (021)
+        'CA' => '021', // Canada
+        'US' => '021', // United States
+
+        // Caribbean (029)
+        'AG' => '029', // Antigua and Barbuda
+        'BS' => '029', // Bahamas
+        'BB' => '029', // Barbados
+        'CU' => '029', // Cuba
+        'DM' => '029', // Dominica
+        'DO' => '029', // Dominican Republic
+        'GD' => '029', // Grenada
+        'HT' => '029', // Haiti
+        'JM' => '029', // Jamaica
+        'KN' => '029', // Saint Kitts and Nevis
+        'LC' => '029', // Saint Lucia
+        'VC' => '029', // Saint Vincent and the Grenadines
+        'TT' => '029', // Trinidad and Tobago
+
+        // Eastern Asia (030)
+        'CN' => '030', // China
+        'HK' => '030', // Hong Kong
+        'JP' => '030', // Japan
+        'KP' => '030', // North Korea
+        'KR' => '030', // South Korea
+        'MO' => '030', // Macao
+        'MN' => '030', // Mongolia
+        'TW' => '030', // Taiwan
+
+        // Southern Asia (034)
+        'AF' => '034', // Afghanistan
+        'BD' => '034', // Bangladesh
+        'BT' => '034', // Bhutan
+        'IO' => '034', // British Indian Ocean Territory
+        'IN' => '034', // India
+        'IR' => '034', // Iran
+        'MV' => '034', // Maldives
+        'NP' => '034', // Nepal
+        'PK' => '034', // Pakistan
+        'LK' => '034', // Sri Lanka
+
+        // South-Eastern Asia (035)
+        'BN' => '035', // Brunei Darussalam
+        'KH' => '035', // Cambodia
+        'ID' => '035', // Indonesia
+        'LA' => '035', // Laos
+        'MY' => '035', // Malaysia
+        'MM' => '035', // Myanmar
+        'PH' => '035', // Philippines
+        'SG' => '035', // Singapore
+        'TH' => '035', // Thailand
+        'TL' => '035', // Timor-Leste
+        'VN' => '035', // Vietnam
+
+        // Central Asia (143)
+        'KZ' => '143', // Kazakhstan
+        'KG' => '143', // Kyrgyzstan
+        'TJ' => '143', // Tajikistan
+        'TM' => '143', // Turkmenistan
+        'UZ' => '143', // Uzbekistan
+
+        // Western Asia (145)
+        'AM' => '145', // Armenia
+        'AZ' => '145', // Azerbaijan
+        'BH' => '145', // Bahrain
+        'CY' => '145', // Cyprus
+        'GE' => '145', // Georgia
+        'IQ' => '145', // Iraq
+        'IL' => '145', // Israel
+        'JO' => '145', // Jordan
+        'KW' => '145', // Kuwait
+        'LB' => '145', // Lebanon
+        'OM' => '145', // Oman
+        'QA' => '145', // Qatar
+        'SA' => '145', // Saudi Arabia
+        'SY' => '145', // Syria
+        'AE' => '145', // United Arab Emirates
+        'YE' => '145', // Yemen
+
+        // Eastern Europe (151)
+        'BY' => '151', // Belarus
+        'BG' => '151', // Bulgaria
+        'CZ' => '151', // Czech Republic
+        'HU' => '151', // Hungary
+        'PL' => '151', // Poland
+        'MD' => '151', // Moldova
+        'RO' => '151', // Romania
+        'RU' => '151', // Russia
+        'SK' => '151', // Slovakia
+        'UA' => '151', // Ukraine
+
+        // Northern Europe (154)
+        'DK' => '154', // Denmark
+        'EE' => '154', // Estonia
+        'FI' => '154', // Finland
+        'IS' => '154', // Iceland
+        'IE' => '154', // Ireland
+        'LV' => '154', // Latvia
+        'LT' => '154', // Lithuania
+        'NO' => '154', // Norway
+        'SE' => '154', // Sweden
+        'GB' => '154', // United Kingdom
+
+        // Southern Europe (039)
+        'AL' => '039', // Albania
+        'AD' => '039', // Andorra
+        'BA' => '039', // Bosnia and Herzegovina
+        'HR' => '039', // Croatia
+        'GR' => '039', // Greece
+        'IT' => '039', // Italy
+        'MT' => '039', // Malta
+        'ME' => '039', // Montenegro
+        'MK' => '039', // North Macedonia
+        'PT' => '039', // Portugal
+        'SM' => '039', // San Marino
+        'RS' => '039', // Serbia
+        'SI' => '039', // Slovenia
+        'ES' => '039', // Spain
+        'VA' => '039', // Vatican City
+
+        // Western Europe (155)
+        'AT' => '155', // Austria
+        'BE' => '155', // Belgium
+        'FR' => '155', // France
+        'DE' => '155', // Germany
+        'LI' => '155', // Liechtenstein
+        'LU' => '155', // Luxembourg
+        'MC' => '155', // Monaco
+        'NL' => '155', // Netherlands
+        'CH' => '155', // Switzerland
+
+        // Australia and New Zealand (053)
+        'AU' => '053', // Australia
+        'NZ' => '053', // New Zealand
+
+        // Melanesia (054)
+        'FJ' => '054', // Fiji
+        'PG' => '054', // Papua New Guinea
+        'SB' => '054', // Solomon Islands
+        'VU' => '054', // Vanuatu
+
+        // Micronesia (057)
+        'KI' => '057', // Kiribati
+        'MH' => '057', // Marshall Islands
+        'FM' => '057', // Micronesia
+        'NR' => '057', // Nauru
+        'PW' => '057', // Palau
+
+        // Polynesia (061)
+        'WS' => '061', // Samoa
+        'TO' => '061', // Tonga
+        'TV' => '061', // Tuvalu
+    ];
+
+    /**
+     * Get the subregion code for a given country code.
+     * 
+     * @param string $countryCode ISO 3166-1 alpha-2 country code
+     * @return string|null UN M49 subregion code or null if not found
+     */
+    public static function getSubregionCode(string $countryCode): ?string
+    {
+        return self::$mapping[strtoupper($countryCode)] ?? null;
+    }
+
+    /**
+     * Get all country codes for a given subregion.
+     * 
+     * @param string $subregionCode UN M49 subregion code
+     * @return array<string> Array of country codes
+     */
+    public static function getCountriesBySubregion(string $subregionCode): array
+    {
+        return array_keys(array_filter(self::$mapping, fn($code) => $code === $subregionCode));
+    }
+
+    /**
+     * Get all available subregion codes.
+     * 
+     * @return array<string> Array of subregion codes
+     */
+    public static function getAvailableSubregionCodes(): array
+    {
+        return array_unique(array_values(self::$mapping));
+    }
+
+    /**
+     * Get all available country codes.
+     * 
+     * @return array<string> Array of country codes
+     */
+    public static function getAvailableCountryCodes(): array
+    {
+        return array_keys(self::$mapping);
+    }
+
+    /**
+     * Check if a country code exists in the mapping.
+     * 
+     * @param string $countryCode ISO 3166-1 alpha-2 country code
+     * @return bool True if the country code exists
+     */
+    public static function hasCountryCode(string $countryCode): bool
+    {
+        return isset(self::$mapping[strtoupper($countryCode)]);
+    }
+
+    /**
+     * Check if a subregion code exists in the mapping.
+     * 
+     * @param string $subregionCode UN M49 subregion code
+     * @return bool True if the subregion code exists
+     */
+    public static function hasSubregionCode(string $subregionCode): bool
+    {
+        return in_array($subregionCode, self::getAvailableSubregionCodes(), true);
+    }
+} 

--- a/src/RegionProvider.php
+++ b/src/RegionProvider.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ydee\IntlRegion;
+
+use Symfony\Component\Intl\Countries;
+use Ydee\IntlRegion\Mapping\ContinentMapping;
+use Ydee\IntlRegion\Mapping\SubregionMapping;
+
+/**
+ * Core class for region-based country filtering.
+ * 
+ * This class provides methods to get countries by continent, subregion,
+ * and to list available codes using UN M49 standard.
+ */
+class RegionProvider
+{
+    /**
+     * Get all countries for a given continent.
+     * 
+     * @param string $continentCode UN M49 continent code
+     * @param string|null $locale Locale for country names (default: 'en')
+     * @return array<string, string> Array of country codes mapped to localized names
+     * @throws \InvalidArgumentException If continent code is invalid
+     */
+    public function getCountriesByContinent(string $continentCode, ?string $locale = 'en'): array
+    {
+        if (!ContinentMapping::hasContinentCode($continentCode)) {
+            throw new \InvalidArgumentException(sprintf('Invalid continent code: %s', $continentCode));
+        }
+
+        $countryCodes = ContinentMapping::getCountriesByContinent($continentCode);
+        return $this->getLocalizedCountryNames($countryCodes, $locale);
+    }
+
+    /**
+     * Get all countries for a given subregion.
+     * 
+     * @param string $subregionCode UN M49 subregion code
+     * @param string|null $locale Locale for country names (default: 'en')
+     * @return array<string, string> Array of country codes mapped to localized names
+     * @throws \InvalidArgumentException If subregion code is invalid
+     */
+    public function getCountriesBySubregion(string $subregionCode, ?string $locale = 'en'): array
+    {
+        if (!SubregionMapping::hasSubregionCode($subregionCode)) {
+            throw new \InvalidArgumentException(sprintf('Invalid subregion code: %s', $subregionCode));
+        }
+
+        $countryCodes = SubregionMapping::getCountriesBySubregion($subregionCode);
+        return $this->getLocalizedCountryNames($countryCodes, $locale);
+    }
+
+    /**
+     * Get the continent code for a given country.
+     * 
+     * @param string $countryCode ISO 3166-1 alpha-2 country code
+     * @return string|null UN M49 continent code or null if not found
+     */
+    public function getContinentCode(string $countryCode): ?string
+    {
+        return ContinentMapping::getContinentCode($countryCode);
+    }
+
+    /**
+     * Get the subregion code for a given country.
+     * 
+     * @param string $countryCode ISO 3166-1 alpha-2 country code
+     * @return string|null UN M49 subregion code or null if not found
+     */
+    public function getSubregionCode(string $countryCode): ?string
+    {
+        return SubregionMapping::getSubregionCode($countryCode);
+    }
+
+    /**
+     * Get all available continent codes.
+     * 
+     * @return array<string> Array of continent codes
+     */
+    public function getAvailableContinentCodes(): array
+    {
+        return ContinentMapping::getAvailableContinentCodes();
+    }
+
+    /**
+     * Get all available subregion codes.
+     * 
+     * @return array<string> Array of subregion codes
+     */
+    public function getAvailableSubregionCodes(): array
+    {
+        return SubregionMapping::getAvailableSubregionCodes();
+    }
+
+    /**
+     * Get all available country codes.
+     * 
+     * @return array<string> Array of country codes
+     */
+    public function getAvailableCountryCodes(): array
+    {
+        return ContinentMapping::getAvailableCountryCodes();
+    }
+
+    /**
+     * Get localized country names for given country codes.
+     * 
+     * @param array<string> $countryCodes Array of ISO 3166-1 alpha-2 country codes
+     * @param string|null $locale Locale for country names (default: 'en')
+     * @return array<string, string> Array of country codes mapped to localized names
+     */
+    private function getLocalizedCountryNames(array $countryCodes, ?string $locale = 'en'): array
+    {
+        $locale = $locale ?? 'en';
+        $result = [];
+
+        foreach ($countryCodes as $countryCode) {
+            $countryName = Countries::getName($countryCode, $locale);
+            if ($countryName !== null) {
+                $result[$countryCode] = $countryName;
+            }
+        }
+
+        // Sort by country name
+        asort($result);
+
+        return $result;
+    }
+
+    /**
+     * Check if a country code exists in the mapping.
+     * 
+     * @param string $countryCode ISO 3166-1 alpha-2 country code
+     * @return bool True if the country code exists
+     */
+    public function hasCountryCode(string $countryCode): bool
+    {
+        return ContinentMapping::hasCountryCode($countryCode);
+    }
+
+    /**
+     * Check if a continent code exists in the mapping.
+     * 
+     * @param string $continentCode UN M49 continent code
+     * @return bool True if the continent code exists
+     */
+    public function hasContinentCode(string $continentCode): bool
+    {
+        return ContinentMapping::hasContinentCode($continentCode);
+    }
+
+    /**
+     * Check if a subregion code exists in the mapping.
+     * 
+     * @param string $subregionCode UN M49 subregion code
+     * @return bool True if the subregion code exists
+     */
+    public function hasSubregionCode(string $subregionCode): bool
+    {
+        return SubregionMapping::hasSubregionCode($subregionCode);
+    }
+
+    /**
+     * Get continent information including name and available countries.
+     * 
+     * @param string $continentCode UN M49 continent code
+     * @param string|null $locale Locale for country names (default: 'en')
+     * @return array{code: string, name: string, countries: array<string, string>}|null Continent information or null if not found
+     */
+    public function getContinentInfo(string $continentCode, ?string $locale = 'en'): ?array
+    {
+        if (!ContinentMapping::hasContinentCode($continentCode)) {
+            return null;
+        }
+
+        $continentNames = [
+            '002' => 'Africa',
+            '019' => 'Americas',
+            '142' => 'Asia',
+            '150' => 'Europe',
+            '009' => 'Oceania',
+        ];
+
+        return [
+            'code' => $continentCode,
+            'name' => $continentNames[$continentCode] ?? $continentCode,
+            'countries' => $this->getCountriesByContinent($continentCode, $locale),
+        ];
+    }
+
+    /**
+     * Get subregion information including name and available countries.
+     * 
+     * @param string $subregionCode UN M49 subregion code
+     * @param string|null $locale Locale for country names (default: 'en')
+     * @return array{code: string, name: string, countries: array<string, string>}|null Subregion information or null if not found
+     */
+    public function getSubregionInfo(string $subregionCode, ?string $locale = 'en'): ?array
+    {
+        if (!SubregionMapping::hasSubregionCode($subregionCode)) {
+            return null;
+        }
+
+        $subregionNames = [
+            '014' => 'Eastern Africa',
+            '017' => 'Middle Africa',
+            '015' => 'Northern Africa',
+            '018' => 'Southern Africa',
+            '011' => 'Western Africa',
+            '005' => 'South America',
+            '013' => 'Central America',
+            '021' => 'Northern America',
+            '029' => 'Caribbean',
+            '030' => 'Eastern Asia',
+            '034' => 'Southern Asia',
+            '035' => 'South-Eastern Asia',
+            '143' => 'Central Asia',
+            '145' => 'Western Asia',
+            '151' => 'Eastern Europe',
+            '154' => 'Northern Europe',
+            '039' => 'Southern Europe',
+            '155' => 'Western Europe',
+            '053' => 'Australia and New Zealand',
+            '054' => 'Melanesia',
+            '057' => 'Micronesia',
+            '061' => 'Polynesia',
+        ];
+
+        return [
+            'code' => $subregionCode,
+            'name' => $subregionNames[$subregionCode] ?? $subregionCode,
+            'countries' => $this->getCountriesBySubregion($subregionCode, $locale),
+        ];
+    }
+} 

--- a/tests/Mapping/ContinentMappingTest.php
+++ b/tests/Mapping/ContinentMappingTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ydee\IntlRegion\Tests\Mapping;
+
+use PHPUnit\Framework\TestCase;
+use Ydee\IntlRegion\Mapping\ContinentMapping;
+
+/**
+ * @covers \Ydee\IntlRegion\Mapping\ContinentMapping
+ */
+class ContinentMappingTest extends TestCase
+{
+    public function testGetContinentCode(): void
+    {
+        $this->assertEquals('002', ContinentMapping::getContinentCode('DZ'));
+        $this->assertEquals('019', ContinentMapping::getContinentCode('US'));
+        $this->assertEquals('142', ContinentMapping::getContinentCode('JP'));
+        $this->assertEquals('150', ContinentMapping::getContinentCode('FR'));
+        $this->assertEquals('009', ContinentMapping::getContinentCode('AU'));
+    }
+
+    public function testGetContinentCodeWithLowerCase(): void
+    {
+        $this->assertEquals('002', ContinentMapping::getContinentCode('dz'));
+        $this->assertEquals('019', ContinentMapping::getContinentCode('us'));
+    }
+
+    public function testGetContinentCodeWithInvalidCode(): void
+    {
+        $this->assertNull(ContinentMapping::getContinentCode('XX'));
+        $this->assertNull(ContinentMapping::getContinentCode(''));
+    }
+
+    public function testGetCountriesByContinent(): void
+    {
+        $africanCountries = ContinentMapping::getCountriesByContinent('002');
+        $this->assertContains('DZ', $africanCountries);
+        $this->assertContains('EG', $africanCountries);
+        $this->assertContains('ZA', $africanCountries);
+
+        $americanCountries = ContinentMapping::getCountriesByContinent('019');
+        $this->assertContains('US', $americanCountries);
+        $this->assertContains('CA', $americanCountries);
+        $this->assertContains('BR', $americanCountries);
+    }
+
+    public function testGetCountriesByContinentWithInvalidCode(): void
+    {
+        $this->assertEmpty(ContinentMapping::getCountriesByContinent('999'));
+    }
+
+    public function testGetAvailableContinentCodes(): void
+    {
+        $codes = ContinentMapping::getAvailableContinentCodes();
+        $this->assertContains('002', $codes);
+        $this->assertContains('019', $codes);
+        $this->assertContains('142', $codes);
+        $this->assertContains('150', $codes);
+        $this->assertContains('009', $codes);
+        $this->assertCount(5, $codes);
+    }
+
+    public function testGetAvailableCountryCodes(): void
+    {
+        $codes = ContinentMapping::getAvailableCountryCodes();
+        $this->assertContains('DZ', $codes);
+        $this->assertContains('US', $codes);
+        $this->assertContains('JP', $codes);
+        $this->assertContains('FR', $codes);
+        $this->assertContains('AU', $codes);
+        $this->assertGreaterThan(100, count($codes));
+    }
+
+    public function testHasCountryCode(): void
+    {
+        $this->assertTrue(ContinentMapping::hasCountryCode('DZ'));
+        $this->assertTrue(ContinentMapping::hasCountryCode('US'));
+        $this->assertTrue(ContinentMapping::hasCountryCode('dz'));
+        $this->assertFalse(ContinentMapping::hasCountryCode('XX'));
+        $this->assertFalse(ContinentMapping::hasCountryCode(''));
+    }
+
+    public function testHasContinentCode(): void
+    {
+        $this->assertTrue(ContinentMapping::hasContinentCode('002'));
+        $this->assertTrue(ContinentMapping::hasContinentCode('019'));
+        $this->assertTrue(ContinentMapping::hasContinentCode('142'));
+        $this->assertTrue(ContinentMapping::hasContinentCode('150'));
+        $this->assertTrue(ContinentMapping::hasContinentCode('009'));
+        $this->assertFalse(ContinentMapping::hasContinentCode('999'));
+    }
+
+    public function testContinentMappingConsistency(): void
+    {
+        // Test that all countries in the mapping have valid continent codes
+        $validContinentCodes = ['002', '019', '142', '150', '009'];
+        
+        foreach (ContinentMapping::getAvailableCountryCodes() as $countryCode) {
+            $continentCode = ContinentMapping::getContinentCode($countryCode);
+            $this->assertNotNull($continentCode, "Country $countryCode should have a continent code");
+            $this->assertContains($continentCode, $validContinentCodes, "Country $countryCode has invalid continent code: $continentCode");
+        }
+    }
+} 


### PR DESCRIPTION
## Changes

- Implements UN M49 continent code mappings (ITR-0001)
- Implements UN M49 subregion code mappings (ITR-0002)
- Adds ContinentMapping and SubregionMapping classes
- Provides comprehensive country-to-region mappings

## Testing
- All mapping tests pass
- Coverage for all continent and subregion codes