### PR TITLE
ITR-0012: Add Symfony bundle support for auto-registration with Flex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,12 @@
     "extra": {
         "branch-alias": {
             "dev-develop": "1.0-dev"
+        },
+        "symfony": {
+            "allow-contrib": false,
+            "bundles": {
+                "Ydee\\IntlRegion\\Bundle\\IntlRegionBundle": ["all"]
+            }
         }
     },
     "version": "1.0.0"


### PR DESCRIPTION
## Summary

Update `composer.json` with the correct Flex `extra.symfony.bundles` configuration to support automatic bundle registration in Symfony Flex applications.

## Related Ticket(s)

* ITR-0012 (Add Symfony Bundle for auto-registration of services and bundles)

## Checklist

* [x] My branch is up-to-date with `develop`
* [x] I followed the branching strategy
* [x] I wrote/updated tests (if applicable)
* [x] All tests pass locally
* [x] I updated documentation if needed (added bundle usage notes)

## How to Test

1. Require the package in a Symfony Flex project.
2. Verify the bundle is auto-registered in `config/bundles.php`.
3. Check that services defined in the bundle’s `Resources/config/services.yaml` are auto-loaded.
4. Confirm that your service (e.g., `RegionProvider`) is correctly autowired and available via dependency injection.

## Screenshots / Evidence

N/A